### PR TITLE
Link to sbin & no reboot req

### DIFF
--- a/META-INF/com/google/android/update-binary
+++ b/META-INF/com/google/android/update-binary
@@ -161,7 +161,7 @@ if $SYSTEMLESS; then
 	IPCEXEC=$INSTALLER/bin/ipc_$ARCH
 	CFGFILE=$INSTALLER/ipc.conf
 
-	[ -d /system/xbin ] && BINDIR=$IPCDIR/system/xbin || BINDIR=$IPCDIR/system/bin
+	BINDIR=$IPCDIR/
 	IPCBIN=$BINDIR/ipc
 
 	rm -rf $IPCDIR
@@ -175,7 +175,7 @@ if $SYSTEMLESS; then
 	print "Patching ipc binary"
 	patchstr $UEVENT_DEF $UEVENT_PATH $IPCBIN
 
-	touch $IPCDIR/auto_mount
+	touch $IPCDIR/skip_mount
 
 	if $BOOTMODE; then
 		mkdir $MODULE_ROOT_DEF/IPControl
@@ -196,7 +196,7 @@ else
 	IPCEXEC=$INSTALLER/bin/ipc_$ARCH
 	CFGFILE=$INSTALLER/ipc.conf
 
-	IPCBIN=/system/bin/ipc
+	IPCBIN=ipc
 	MODINFO=$IPCDIR/ipc.prop
 	INITRUN=$INITDIR/02ipcd_launcher
 

--- a/META-INF/com/google/android/update-binary
+++ b/META-INF/com/google/android/update-binary
@@ -222,5 +222,12 @@ fi
 
 ui_print " "
 ui_print "Installation completed successfully!"
+ui_print " "
+ui_print "✓ Module ready for use!"
+ui_print "  No reboot required..."
+ui_print " "
+
+$IPCDIR/service.sh
+
 cleanup
 exit 0

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@
 # Set to true if you do *NOT* want Magisk to mount
 # any files for you. Most modules would NOT want
 # to set this flag to true
-SKIPMOUNT=false
+SKIPMOUNT=true
 
 # Set to true if you need to load system.prop
 PROPFILE=false
@@ -141,9 +141,9 @@ on_install() {
     cancel "! Unsupported platform detected!"
   fi
 
-  [ -d /system/xbin ] && BINDIR=$MODPATH/system/xbin || BINDIR=$MODPATH/system/bin
+  #[ -d /system/xbin ] && BINDIR=$MODPATH/system/xbin || BINDIR=$MODPATH/system/bin
 
-  mkdir -p $BINDIR
+  #mkdir -p $BINDIR
 
   case $ARCH in
     arm*) ARCH_32BIT=arm ;;
@@ -155,7 +155,7 @@ on_install() {
   ui_print "- Extracting module files"
   unzip -oj "$ZIPFILE" $IPCFILES -d $MODPATH >&2
 
-  mv -f $MODPATH/ipc_$ARCH_32BIT $BINDIR/ipc
+  mv -f $MODPATH/ipc_$ARCH_32BIT $MODPATH/ipc
 
   UEVENT_DEF=/sys/class/power_supply/battery/uevent
 
@@ -165,7 +165,7 @@ on_install() {
 
   ui_print "- Patching ipc binary"
 
-  sed -i "s|$UEVENT_DEF|$UEVENT_PATH|g" $BINDIR/ipc
+  sed -i "s|$UEVENT_DEF|$UEVENT_PATH|g" $MODPATH/ipc
 }
 
 # Only some special files require specific permissions
@@ -175,7 +175,7 @@ on_install() {
 set_permissions() {
   # The following is the default rule, DO NOT remove
   set_perm_recursive $MODPATH 0 0    0755 0644
-  set_perm_recursive $BINDIR  0 2000 0755 0755
+  set_perm $MODPATH/ipc  0 2000 0755 0755
 
   # Here are some examples:
   # set_perm_recursive  $MODPATH/system/lib       0     0       0755      0644

--- a/module.prop
+++ b/module.prop
@@ -1,6 +1,6 @@
 id=IPControl
 name=Input Power Control
 version=2.1.0
-versionCode=33
+versionCode=34
 author=Jaymin Suthar
 description=Completely native input power control tool written purely in C++ for performance and stability

--- a/service.sh
+++ b/service.sh
@@ -16,4 +16,27 @@
 # You should have received a copy of the GNU General Public License
 # along with IPControl.  If not, see <https://www.gnu.org/licenses/>.
 
-ipc -d launch
+MODDIR=${0%/*}
+
+IMGDIR=/sbin/.core/img
+UPDDIR=/data/adb/modules_update
+id=IPControl
+
+if [ -e ${UPDDIR}/${id}/ipc ]; then
+
+    ln -sf ${UPDDIR}/${id}/ipc /sbin/ipc
+    HOME=${UPDDIR}/${id}
+
+elif [ -e ${IMGDIR}/${id}/rclone-wrapper.sh ]; then
+
+    ln -sf ${IMGDIR}/${id}/ipc /sbin/ipc
+    HOME=${IMGDIR}/${id}
+
+else
+
+    ln -sf ${MODDIR}/ipc /sbin/ipc
+    HOME=${MODDIR}
+
+fi
+
+$HOME/ipc -d launch

--- a/service.sh
+++ b/service.sh
@@ -39,4 +39,13 @@ else
 
 fi
 
-$HOME/ipc -d launch
+
+if $HOME/ipc -d launch >> /dev/null 2>&1; then
+
+echo "✓ Daemon started successfully"
+
+else
+
+echo "* Daemon failed to start"
+
+fi


### PR DESCRIPTION
I have made two major changes to this module. 

1. Symlink `ipc` binary to sbin instead mount binding to /system as its not required.
In my experience it's best not to use binding unless absolutely required. 

2. Allow module to install, update & operate without rebooting
Included simply for convenience :) 
