### PR TITLE
modify the way update-binary mounts /system

### DIFF
--- a/META-INF/com/google/android/update-binary
+++ b/META-INF/com/google/android/update-binary
@@ -98,11 +98,9 @@ is_mounted /data || mount /data || abort "Error occured while mounting /data"
 MAGISK_VER=$(getprop MAGISK_VER_CODE $DE_DATA/magisk/util_functions.sh)
 [ -n "$MAGISK_VER" ] && [ $MAGISK_VER -ge 18105 ] || SYSTEMLESS=false
 
-ui_print "- Mounting /system(ro), /vendor(ro), /data, /cache"
-mount -o ro /system 2>/dev/null
-mount -o ro /vendor 2>/dev/null
-mount /data 2>/dev/null
-mount /cache 2>/dev/null
+$SYSTEMLESS && RW=ro || RW=rw
+ui_print "- Mounting /system($RW)..."
+mount -o $RW /system 2>/dev/null
 
 if [ ! -f '/system/build.prop' ]; then
   ui_print "! Failed: /system could not be mounted!"

--- a/META-INF/com/google/android/update-binary
+++ b/META-INF/com/google/android/update-binary
@@ -98,8 +98,17 @@ is_mounted /data || mount /data || abort "Error occured while mounting /data"
 MAGISK_VER=$(getprop MAGISK_VER_CODE $DE_DATA/magisk/util_functions.sh)
 [ -n "$MAGISK_VER" ] && [ $MAGISK_VER -ge 18105 ] || SYSTEMLESS=false
 
-$SYSTEMLESS && RW=ro || RW=rw
-mount -o $RW /system || mount -o $RW,remount /system || abort "Error occured while mounting /system"
+ui_print "- Mounting /system(ro), /vendor(ro), /data, /cache"
+mount -o ro /system 2>/dev/null
+mount -o ro /vendor 2>/dev/null
+mount /data 2>/dev/null
+mount /cache 2>/dev/null
+
+if [ ! -f '/system/build.prop' ]; then
+  ui_print "! Failed: /system could not be mounted!"
+  exit 1
+fi
+
 if [ -f /system/init ]; then
 	mkdir /system_root
 	mount -o move /system /system_root


### PR DESCRIPTION
I'm extremely new to magisk modules (in fact, this is the first time Iook into one), so excuse the ignorance.

This PR should solve issue #16 as it mounts /system as it does in https://github.com/nathanchance/magisk-modules/blob/master/META-INF/com/google/android/update-binary .

This removes the systemless check (and mounts /data twice), but it works if installed from the magisk app module manager. Probably needs some modification before merging